### PR TITLE
msm8996-common: Use more conservative VM parameters

### DIFF
--- a/init/init_msm8996.cpp
+++ b/init/init_msm8996.cpp
@@ -99,8 +99,8 @@ void vendor_load_properties()
     check_device();
 
     property_set("dalvik.vm.heapstartsize", "8m");
-    property_set("dalvik.vm.heapgrowthlimit", "384m");
-    property_set("dalvik.vm.heapsize", "1024m");
+    property_set("dalvik.vm.heapgrowthlimit", "256m");
+    property_set("dalvik.vm.heapsize", "512m");
     property_set("dalvik.vm.heaptargetutilization", "0.75");
     property_set("dalvik.vm.heapminfree", heapminfree);
     property_set("dalvik.vm.heapmaxfree", heapmaxfree);


### PR DESCRIPTION
The maximum heap size for each virtual machine is 1GB. This is too big
and puts too much pressure on both the garbage collector when it tries
to perform collections in older generations. The symptoms are simple,
some applications will allocate objects that live long enough to be
promoted to older generations, escaping the efficient CMS collections.
Eventually, a stop-the-world collection will go through this large block
of memory and cause applications to pause for too long.

Additionally, the out of memory killer follows a LRU approach where it
tries to kill older applciations to make room for new ones. The problem
arises when the least recently used applications don't have large heaps
but the most recent ones do. When this happens the system halts to a
crawl while older apps and services are killed and respawned in a never
ending cycle of jankiness.

These values were obtained experimentally but actually match the
defaults for devices with >2gb of ram and xhdpi.

Change-Id: I73a92269ceac61dd4d4c1b1600f55a21534a27a0